### PR TITLE
Initialize variable lists, generate object IDs, fix variable debug dump

### DIFF
--- a/TAs/optee_ta/AuthVars/AuthVars.c
+++ b/TAs/optee_ta/AuthVars/AuthVars.c
@@ -54,6 +54,7 @@ BOOL AuthVarIsRuntime = false;
 // 
 TEE_Result TA_CreateEntryPoint(void)
 {
+    TEE_Result status;
     // If we've been here before, don't init again.
     if (AuthVarInitialized)
     {
@@ -62,8 +63,10 @@ TEE_Result TA_CreateEntryPoint(void)
     }
 
     // If we fail to open storage we cannot continue.
-    if (!AuthVarInitStorage())
+    status = AuthVarInitStorage();
+    if (status != TEE_SUCCESS)
     {
+        EMSG("AuthVars failed to initialize with error 0x%x", status);
         TEE_Panic(TEE_ERROR_BAD_STATE);
     }
 

--- a/TAs/optee_ta/AuthVars/src/include/varmgmt.h
+++ b/TAs/optee_ta/AuthVars/src/include/varmgmt.h
@@ -131,6 +131,9 @@ QueryByAttribute(
 );
 
 #ifdef AUTHVAR_DEBUG
+CHAR*
+CovnertWCharToChar( WCHAR *Unicode, CHAR *Ascii, UINT32 AsciiBufferLength);
+
 VOID
 AuthVarDumpVarListImpl(
     VOID


### PR DESCRIPTION
These fixes allow the Authvars TA to run enough for basic testing to start.
- In memory variable lists are now initialized properly
- On clean RPMB TEE_StartPersistentObjectEnumerator() will return TEE_ERROR_ITEM_NOT_FOUND, handle this.
- Even though we don't need to keep track of the unique object IDs used to create persistent objects, OP-TEE requires they be unique. Use a truncated SHA256 hash of (GUID + Variable Name) as the object ID when creating a new variable. This ID is picked back up when enumerating the persistent objects during initialization (although we don't currently need it again).
- AuthVarDumpVarList() updated to work again, also prints volatile variables as well.

Note: The Authvar TA is currently not tracking newly created variables correctly and returns TEE_ERROR_ACCESS_CONFLICT because it attempts to create a new persistent object but the SHA256 hash always produce the same object ID for the same GUID + name.