### PR TITLE
Track NV data use

### DIFF
--- a/TAs/optee_ta/AuthVars/src/include/varmgmt.h
+++ b/TAs/optee_ta/AuthVars/src/include/varmgmt.h
@@ -45,10 +45,11 @@
  // Maximum number of variables we'll track
 #define MAX_AUTHVAR_ENTRIES     (256)
 
- // MUST NOT EXCEED TA_DATA_SIZE (user_ta_header_defines.h)
+// (MAX_NV_STORAGE + MAX_VOLATILE_STORAGE) MUST NOT EXCEED TA_DATA_SIZE (user_ta_header_defines.h)
+// Maximum possible storage for non-volatile vars
 #define MAX_NV_STORAGE         (64 * 1024) // = 64k
 
- // Maximum possible storage (TA_DATA_SIZE) for volatile vars
+// Maximum possible storage for volatile vars
 #define MAX_VOLATILE_STORAGE    (64 * 1024)   // = 64k
 
 // (guid,name) digest quadword count

--- a/TAs/optee_ta/AuthVars/src/include/varmgmt.h
+++ b/TAs/optee_ta/AuthVars/src/include/varmgmt.h
@@ -45,11 +45,11 @@
  // Maximum number of variables we'll track
 #define MAX_AUTHVAR_ENTRIES     (256)
 
- // MUST MATCH TA_DATA_SIZE (user_ta_header_defines.h)
-#define NV_AUTHVAR_SIZE         (512 * 1024) // = 0x80000
+ // MUST NOT EXCEED TA_DATA_SIZE (user_ta_header_defines.h)
+#define MAX_NV_STORAGE         (64 * 1024) // = 64k
 
  // Maximum possible storage (TA_DATA_SIZE) for volatile vars
-#define MAX_VOLATILE_STORAGE    (0x40000)   // = NV_AUTHVAR_SIZE / 2
+#define MAX_VOLATILE_STORAGE    (64 * 1024)   // = 64k
 
 // (guid,name) digest quadword count
 #define TEE_DIGEST_QWORDS      ((TEE_SHA256_HASH_SIZE) / sizeof(UINT64))

--- a/TAs/optee_ta/AuthVars/user_ta_header_defines.h
+++ b/TAs/optee_ta/AuthVars/user_ta_header_defines.h
@@ -44,7 +44,7 @@
 
 #define TA_FLAGS                    (TA_FLAG_SINGLE_INSTANCE | TA_FLAG_INSTANCE_KEEP_ALIVE | TA_FLAG_MULTI_SESSION)
 #define TA_STACK_SIZE               (64 * 1024)
-#define TA_DATA_SIZE                (512 * 1024) // = 512k, must be larger than MAX_NV_STORAGE + MAX_VOLATILE_STROAGE
+#define TA_DATA_SIZE                (256 * 1024) // = 256k (double worst case)
 
 #define TA_CURRENT_TA_EXT_PROPERTIES \
     { "gp.ta.description", USER_TA_PROP_TYPE_STRING, \

--- a/TAs/optee_ta/AuthVars/user_ta_header_defines.h
+++ b/TAs/optee_ta/AuthVars/user_ta_header_defines.h
@@ -44,7 +44,14 @@
 
 #define TA_FLAGS                    (TA_FLAG_SINGLE_INSTANCE | TA_FLAG_INSTANCE_KEEP_ALIVE | TA_FLAG_MULTI_SESSION)
 #define TA_STACK_SIZE               (64 * 1024)
-#define TA_DATA_SIZE                (256 * 1024) // = 256k (double worst case)
+/*
+ * Worst case memory requirements:
+ * Volatile + Non-Volatile storage  = 64k + 64k 
+ * Max optee buffer size            = 16k
+ * Max Cert store size              = 16k * 2
+ *                                  = 176k
+*/
+#define TA_DATA_SIZE                (192 * 1024) // ( worst case + 16k saftey margin)
 
 #define TA_CURRENT_TA_EXT_PROPERTIES \
     { "gp.ta.description", USER_TA_PROP_TYPE_STRING, \

--- a/TAs/optee_ta/AuthVars/user_ta_header_defines.h
+++ b/TAs/optee_ta/AuthVars/user_ta_header_defines.h
@@ -44,7 +44,7 @@
 
 #define TA_FLAGS                    (TA_FLAG_SINGLE_INSTANCE | TA_FLAG_INSTANCE_KEEP_ALIVE | TA_FLAG_MULTI_SESSION)
 #define TA_STACK_SIZE               (64 * 1024)
-#define TA_DATA_SIZE                (512 * 1024) // = 256k (double worst case)
+#define TA_DATA_SIZE                (512 * 1024) // = 512k, must be larger than MAX_NV_STORAGE + MAX_VOLATILE_STROAGE
 
 #define TA_CURRENT_TA_EXT_PROPERTIES \
     { "gp.ta.description", USER_TA_PROP_TYPE_STRING, \

--- a/TAs/optee_ta/AuthVars/user_ta_header_defines.h
+++ b/TAs/optee_ta/AuthVars/user_ta_header_defines.h
@@ -44,7 +44,7 @@
 
 #define TA_FLAGS                    (TA_FLAG_SINGLE_INSTANCE | TA_FLAG_INSTANCE_KEEP_ALIVE | TA_FLAG_MULTI_SESSION)
 #define TA_STACK_SIZE               (64 * 1024)
-#define TA_DATA_SIZE                (512 * 1024)
+#define TA_DATA_SIZE                (512 * 1024) // = 256k (double worst case)
 
 #define TA_CURRENT_TA_EXT_PROPERTIES \
     { "gp.ta.description", USER_TA_PROP_TYPE_STRING, \


### PR DESCRIPTION
Track the current utilization of NV memory (same mechanism as volatile memory). The TA was allowing enough variables to be created that OP-TEE was running out of internal heap space.

MAX_NV_STORAGE is set to 64K (Windows recommended miniumum), as is MAX_VOLATILE_STROAGE.

