### PR TITLE
Fix for debug print and NV delete

### DIFF
--- a/TAs/optee_ta/AuthVars/src/varmgmt.c
+++ b/TAs/optee_ta/AuthVars/src/varmgmt.c
@@ -1528,6 +1528,9 @@ NvDeleteVariable(
     VarList[i].Var = NULL;
     VarList[i].ObjectID = 0;
 
+    // Clear metadata
+    memset(&(VarList[i]), 0, sizeof(AUTHVAR_META));
+
     // If necessary, update next free
     if (i < NextFreeIdx)
     {
@@ -1726,7 +1729,7 @@ ConvertWCharToChar(
 )
 {
     CHAR *returnPtr = Ascii;
-    while (Unicode != L'\0' && AsciiBufferLength > 1) {
+    while (*Unicode != L'\0' && AsciiBufferLength > 1) {
         if (*Unicode <= 0x7F) {
             *Ascii = (CHAR)*Unicode;
         }


### PR DESCRIPTION
Small fix for the debug code, it wasn't correctly detecting deleted varaibles, and was reading too far through strings when converting to ascii.

I figure its safest to completely clear the meta data when deleting a variable.