### PR TITLE
** DO NOT MERGE** Improve TPM startup flow and nv enable

### DIFF
--- a/TAs/optee_ta/fTPM/include/fTPM.h
+++ b/TAs/optee_ta/fTPM/include/fTPM.h
@@ -105,4 +105,6 @@ typedef union {
 } TPM_CHIP_STATE;
 
 extern TPM_CHIP_STATE g_chipFlags;
+extern bool g_inFailureMode;
+
 #endif /* FTPM_TA_H */

--- a/TAs/optee_ta/fTPM/platform/NVMem.c
+++ b/TAs/optee_ta/fTPM/platform/NVMem.c
@@ -379,7 +379,7 @@ _plat__NVEnable(
     _plat__NvInitFromStorage();
 
     // Were we successful?
-    if (s_NVChipFileNeedsManufacture == FALSE || s_NVInitialized == FALSE) {
+    if (s_NVChipFileNeedsManufacture == TRUE || s_NVInitialized == FALSE) {
         // Arriving here means one of two things: Either there existed no
         // NV state before we came along and we just (re)initialized our
         // storage. Or there is an error condition preventing us from 

--- a/TAs/optee_ta/fTPM/platform/RunCommand.c
+++ b/TAs/optee_ta/fTPM/platform/RunCommand.c
@@ -94,5 +94,6 @@ _plat__Fail(
 #if FAIL_TRACE
     EMSG("%s:%d", s_failFunction, s_failLine);
 #endif
+    longjmp(&(s_jumpBuffer[0]), 1);
     TEE_Panic(TEE_ERROR_BAD_STATE);
 }


### PR DESCRIPTION
NvEnable() could be called multiple times without s_NVInitialized getting set to TRUE. An access conflict error would be generated, then ignored.

This should no longer happen.

Also improved handling of startup failure, and implemented the setjmp/longjmp calls.