### PR TITLE
Use default behaviour to run CI on all branches

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,6 +1,3 @@
-trigger:
-- master
-
 jobs:
   - job: Build
     pool:


### PR DESCRIPTION
By default devops will now run CI builds for any branch unless an explicit trigger is set. Removing the trigger field here should cause devops to verify all branches.