### PR TITLE
update respLen after succesfully executing a TPM command

### DIFF
--- a/TAs/optee_ta/fTPM/fTPM.c
+++ b/TAs/optee_ta/fTPM/fTPM.c
@@ -319,6 +319,7 @@ static TEE_Result fTPM_Submit_Command(uint32_t  param_types,
     DMSG("Success, RS: 0x%x\n", respLen);
 #endif
 
+    params[1].memref.size = respLen;
     return TEE_SUCCESS;
 }
 


### PR DESCRIPTION
Update the _size_ field of the OPTEE buffer containing the response of a TPM command. This is a redundant update, as the size information is contained in the response itself. However, this same update is performed when executing PPI commands, therefore adding it could be useful to have more coherency.