### PR TITLE
Free pVar and clear ObjectID field when exeeding nv storage size

### DIFF
--- a/TAs/optee_ta/AuthVars/src/varmgmt.c
+++ b/TAs/optee_ta/AuthVars/src/varmgmt.c
@@ -235,6 +235,8 @@ AuthVarInitStorage(
         {
             status = TEE_ERROR_OUT_OF_MEMORY;
             EMSG("Failed AuthVarInit: Exceeds non-volatile variable max allocation.");
+            TEE_Free(pVar);
+            VarList[i].ObjectID = 0;
             goto Cleanup;
         }
 


### PR DESCRIPTION
When allocating a new variable that would exceed NV storage capacity,
free the allocated pointer and clear the assigned ObjectID. Free'ing
the pointer eliminates a potential memleak and clearing the ObjectID
ensures that we have no dangling object in the variable list VarList.