### PR TITLE
Add `$schema` to `cgmanifest.json`

### DIFF
--- a/external/cgmanifest.json
+++ b/external/cgmanifest.json
@@ -1,41 +1,42 @@
 {
-    "Registrations": [
-        {
-            "component": {
-                "type": "git",
-                "git": {
-                    "repositoryUrl": "https://github.com/ms-iot/optee_os",
-                    "commitHash": "bc454ea594eefeed0ffb4baa1fdc09f47cdc1704"
-                }
-            }
-        },
-        {
-            "component": {
-                "type": "git",
-                "git": {
-                    "repositoryUrl": "https://github.com/Microsoft/ms-tpm-20-ref.git",
-                    "commitHash": "6cb570e90317c7927a0c6da86a27777376a9a433"
-                }
-            }
-        },
-        {
-            "component": {
-                "type": "git",
-                "git": {
-                    "repositoryUrl": "https://github.com/openssl/openssl.git",
-                    "commitHash": "3d753b0cefaa7e3d4b5d12d7805b20fabff1f385"
-                }
-            }
-        },
-        {
-            "component": {
-                "type": "git",
-                "git": {
-                    "repositoryUrl": "https://github.com/wolfSSL/wolfssl.git",
-                    "commitHash": "74ebf510a3d73e98767eac26082eabdc84e19d31"
-                }
-            }
+  "$schema": "https://json.schemastore.org/component-detection-manifest.json",
+  "Registrations": [
+    {
+      "component": {
+        "type": "git",
+        "git": {
+          "repositoryUrl": "https://github.com/ms-iot/optee_os",
+          "commitHash": "bc454ea594eefeed0ffb4baa1fdc09f47cdc1704"
         }
-    ],
-    "Version": 1
+      }
+    },
+    {
+      "component": {
+        "type": "git",
+        "git": {
+          "repositoryUrl": "https://github.com/Microsoft/ms-tpm-20-ref.git",
+          "commitHash": "6cb570e90317c7927a0c6da86a27777376a9a433"
+        }
+      }
+    },
+    {
+      "component": {
+        "type": "git",
+        "git": {
+          "repositoryUrl": "https://github.com/openssl/openssl.git",
+          "commitHash": "3d753b0cefaa7e3d4b5d12d7805b20fabff1f385"
+        }
+      }
+    },
+    {
+      "component": {
+        "type": "git",
+        "git": {
+          "repositoryUrl": "https://github.com/wolfSSL/wolfssl.git",
+          "commitHash": "74ebf510a3d73e98767eac26082eabdc84e19d31"
+        }
+      }
+    }
+  ],
+  "Version": 1
 }


### PR DESCRIPTION
This pull request adds the JSON schema for `cgmanifest.json`.

## FAQ

### Why?

A JSON schema helps you to ensure that your `cgmanifest.json` file is valid.
JSON schema validation is a build-in feature in most modern IDEs like Visual Studio and Visual Studio Code.
Most modern IDEs also provide code-completion for JSON schemas.

### How can I validate my `cgmanifest.json` file?

Most modern IDEs like Visual Studio and Visual Studio Code have a built-in feature to validate JSON files.
You can also use [this small script](https://github.com/JamieMagee/verify-cgmanifest) to validate your `cgmanifest.json` file.

### Why does it suggest camel case for the properties?

Component Detection is able to read camel case and pascal case properties.
However, the JSON schema doesn't have a case-insensitive mode.
We therefore suggest camel case as it's the most common format for JSON.

### Why is the diff so large?

To deserialize the `cgmanifest.json` file, we use [`JSON.parse()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse).
However, to serialize the JSON again we use [`prettier`](https://prettier.io/).
We found that, in general, it gave smaller diffs than the default [`JSON.stringify()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify) function.